### PR TITLE
Move texture reader attributes into separate `Texture` object

### DIFF
--- a/xnb/objects/Texture2D.py
+++ b/xnb/objects/Texture2D.py
@@ -17,9 +17,7 @@ class Texture2D:
     surface_format: SurfaceFormat
     textures: List[bytes]
     image_data: bytes
-
-    def __init__(self) -> None:
-        self.logger = logging.getLogger(__name__)
+    logger: logging.Logger = logging.getLogger(__name__)
 
     def save(self, path: str, format: str = 'png') -> None:
         """Save the image data into a readable file"""

--- a/xnb/objects/Texture2D.py
+++ b/xnb/objects/Texture2D.py
@@ -18,10 +18,6 @@ class Texture2D:
         self.image_data: bytes = bytes()
         self.logger = logging.getLogger(__name__)
 
-    @property
-    def content(self) -> List[bytes]:
-        return self.images()
-
     def save(self, path: str, format: str = 'png') -> None:
         """Save the image data into a readable file"""
         images = self.images(format)

--- a/xnb/objects/Texture2D.py
+++ b/xnb/objects/Texture2D.py
@@ -1,6 +1,6 @@
 
 from __future__ import annotations
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List
 from PIL import Image
 
@@ -12,11 +12,11 @@ import io
 
 @dataclass
 class Texture2D:
-    width: int
-    height: int
-    surface_format: SurfaceFormat
-    textures: List[bytes]
-    image_data: bytes
+    width: int = 0
+    height: int = 0
+    surface_format: SurfaceFormat = SurfaceFormat.Bgr565
+    textures: List[bytes] = field(default_factory=list)
+    image_data: bytes = bytes()
     logger: logging.Logger = logging.getLogger(__name__)
 
     def save(self, path: str, format: str = 'png') -> None:

--- a/xnb/objects/Texture2D.py
+++ b/xnb/objects/Texture2D.py
@@ -1,5 +1,6 @@
 
 from __future__ import annotations
+from dataclasses import dataclass
 from typing import List
 from PIL import Image
 
@@ -9,13 +10,15 @@ import logging
 import numpy
 import io
 
+@dataclass
 class Texture2D:
+    width: int
+    height: int
+    surface_format: SurfaceFormat
+    textures: List[bytes]
+    image_data: bytes
+
     def __init__(self) -> None:
-        self.width: int | None = None
-        self.height: int | None = None
-        self.surface_format: SurfaceFormat | None = None
-        self.textures: List[bytes] = []
-        self.image_data: bytes = bytes()
         self.logger = logging.getLogger(__name__)
 
     def save(self, path: str, format: str = 'png') -> None:

--- a/xnb/objects/Texture2D.py
+++ b/xnb/objects/Texture2D.py
@@ -1,0 +1,89 @@
+
+from __future__ import annotations
+from typing import List
+from PIL import Image
+
+from ..constants import SurfaceFormat
+
+import logging
+import numpy
+import io
+
+class Texture2D:
+    def __init__(self) -> None:
+        self.width: int | None = None
+        self.height: int | None = None
+        self.surface_format: SurfaceFormat | None = None
+        self.textures: List[bytes] = []
+        self.image_data: bytes = bytes()
+        self.logger = logging.getLogger(__name__)
+
+    @property
+    def content(self) -> List[bytes]:
+        return self.images()
+
+    def save(self, path: str, format: str = 'png') -> None:
+        """Save the image data into a readable file"""
+        images = self.images(format)
+
+        if len(images) <= 0:
+            self.logger.info('No images were parsed.')
+            return
+
+        for index, image in enumerate(images):
+            with open(f'{path}-{index}.{format.lower()}', 'wb') as f:
+                f.write(image)
+
+    def images(self, format: str = 'png') -> List[bytes]:
+        """Convert the raw image(s) into a readable image format"""
+        if not self.textures:
+            self.logger.info('Texture data is empty.')
+            return list()
+
+        return [
+            self.texture_to_image(texture, format, index)
+            for index, texture in enumerate(self.textures)
+        ]
+
+    def texture_to_image(self, texture: bytes, format: str = 'png', level: int = 0) -> bytes:
+        bitmap = numpy.frombuffer(texture, dtype=numpy.uint8).copy()
+
+        if len(bitmap) <= 0:
+            return bytes()
+
+        bitmap = self.convert_texture_to_rgba(bitmap)
+        width = self.width >> level
+        height = self.height >> level
+
+        try:
+            # Reshape the flattened array to 3D (height, width, channels)
+            image_data = bitmap.reshape((height, width, 4))
+        except ValueError as e:
+            self.logger.warning(f'Failed to reshape image: {e}')
+            return bytes()
+
+        output = io.BytesIO()
+        image = Image.fromarray(image_data.astype('uint8'))
+        image.save(output, format)
+        return output.getvalue()
+
+    def convert_texture_to_rgba(self, bitmap: numpy.ndarray) -> numpy.ndarray:
+        """Convert the given surface format to RGBA"""
+        format_converters = {
+            SurfaceFormat.Bgr565: self.convert_bgra_to_rgba
+            # TODO: Add more converters...
+        }
+
+        if not (format := format_converters.get(self.surface_format)):
+            self.logger.warning(f'Unsupported surface format: {self.surface_format}')
+            return bitmap
+
+        return format(bitmap)
+
+    @staticmethod
+    def convert_bgra_to_rgba(bitmap: numpy.ndarray) -> numpy.ndarray:
+        """Convert BGRA to RGBA"""
+        for i in range(0, len(bitmap), 4):
+            bitmap[i], bitmap[i + 2] = bitmap[i + 2], bitmap[i]
+
+        return bitmap

--- a/xnb/objects/__init__.py
+++ b/xnb/objects/__init__.py
@@ -1,0 +1,2 @@
+
+from .Texture2D import Texture2D

--- a/xnb/reader.py
+++ b/xnb/reader.py
@@ -47,7 +47,7 @@ class XNBReader:
             return
 
         for reader in self.readers:
-            reader.save(path)
+            reader.content.save(path)
 
     def deserialize(self) -> None:
         """Deserialize the xnb file"""

--- a/xnb/readers/Base.py
+++ b/xnb/readers/Base.py
@@ -22,7 +22,3 @@ class BaseReader:
     def deserialize(self) -> None:
         """Deserialize the xnb data"""
         ...
-
-    def save(self, path: str) -> None:
-        """Save the xnb data into a readable file"""
-        ...

--- a/xnb/readers/Texture2DReader.py
+++ b/xnb/readers/Texture2DReader.py
@@ -1,5 +1,6 @@
 
 from __future__ import annotations
+from typing import List
 
 from ..constants import SurfaceFormat
 from ..objects import Texture2D
@@ -10,6 +11,10 @@ class Texture2DReader(BaseReader):
     def __init__(self, stream: StreamIn) -> None:
         self.texture: Texture2D | None = Texture2D()
         super().__init__(stream)
+
+    @property
+    def content(self) -> Texture2D:
+        return self.texture
 
     def deserialize(self) -> Texture2D:
         # Read texture format, width, height, and number of textures

--- a/xnb/readers/Texture2DReader.py
+++ b/xnb/readers/Texture2DReader.py
@@ -1,108 +1,27 @@
 
 from __future__ import annotations
-from typing import List
-from PIL import Image
 
 from ..constants import SurfaceFormat
+from ..objects import Texture2D
 from ..streams import StreamIn
 from .Base import BaseReader
 
-import logging
-import numpy
-import io
-
 class Texture2DReader(BaseReader):
     def __init__(self, stream: StreamIn) -> None:
-        self.width: int | None = None
-        self.height: int | None = None
-        self.surface_format: SurfaceFormat | None = None
-        self.textures: List[bytes] = []
-        self.image_data: bytes = bytes()
-        self.logger = logging.getLogger(__name__)
+        self.texture: Texture2D | None = Texture2D()
         super().__init__(stream)
 
-    @property
-    def content(self) -> List[bytes]:
-        return self.images()
-
-    def deserialize(self) -> None:
+    def deserialize(self) -> Texture2D:
         # Read texture format, width, height, and number of textures
-        self.surface_format = SurfaceFormat(self.stream.s32())
-        self.width = self.stream.s32()
-        self.height = self.stream.s32()
+        self.texture.surface_format = SurfaceFormat(self.stream.s32())
+        self.texture.width = self.stream.s32()
+        self.texture.height = self.stream.s32()
         level_count = self.stream.s32()
 
         # Read sprites
         for _ in range(level_count):
             sprite_size = self.stream.u32()
             spite_data = self.stream.read(sprite_size)
-            self.textures.append(spite_data)
+            self.texture.textures.append(spite_data)
 
-    def save(self, path: str, format: str = 'png') -> None:
-        """Save the image data into a readable file"""
-        images = self.images(format)
-
-        if len(images) <= 0:
-            self.logger.info('No images were parsed.')
-            return
-
-        for index, image in enumerate(images):
-            with open(f'{path}-{index}.{format.lower()}', 'wb') as f:
-                f.write(image)
-
-    def images(self, format: str = 'png') -> List[bytes]:
-        """Convert the raw image(s) into a readable image format"""
-        if not self.textures:
-            self.logger.info('Texture data is empty.')
-            return list()
-
-        return [
-            self.texture_to_image(texture, format, index)
-            for index, texture in enumerate(self.textures)
-        ]
-
-    def texture_to_image(self, texture: bytes, format: str = 'png', level: int = 0) -> bytes:
-        bitmap = numpy.frombuffer(texture, dtype=numpy.uint8).copy()
-
-        if len(bitmap) <= 0:
-            return bytes()
-
-        bitmap = self.convert_texture_to_rgba(bitmap)
-        width = self.width >> level
-        height = self.height >> level
-
-        try:
-            # Reshape the flattened array to 3D (height, width, channels)
-            image_data = bitmap.reshape((height, width, 4))
-        except ValueError as e:
-            self.logger.warning(f'Failed to reshape image: {e}')
-            return bytes()
-
-        output = io.BytesIO()
-        image = Image.fromarray(image_data.astype('uint8'))
-        image.save(output, format)
-        return output.getvalue()
-
-    def convert_texture_to_rgba(self, bitmap: numpy.ndarray) -> numpy.ndarray:
-        """Convert the given surface format to RGBA"""
-        format_converters = {
-            SurfaceFormat.Bgr565: self.convert_bgra_to_rgba
-            # TODO: Add more converters...
-        }
-
-        if not (format := format_converters.get(self.surface_format)):
-            self.logger.warning(f'Unsupported surface format: {self.surface_format}')
-            return bitmap
-
-        return format(bitmap)
-
-    @staticmethod
-    def convert_bgra_to_rgba(bitmap: numpy.ndarray) -> numpy.ndarray:
-        """Convert BGRA to RGBA"""
-        for i in range(0, len(bitmap), 4):
-            b0 = bitmap[i]
-
-            bitmap[i] = bitmap[i + 2]
-            bitmap[i + 2] = b0
-
-        return bitmap
+        return self.texture

--- a/xnb/readers/Texture2DReader.py
+++ b/xnb/readers/Texture2DReader.py
@@ -9,7 +9,7 @@ from .Base import BaseReader
 
 class Texture2DReader(BaseReader):
     def __init__(self, stream: StreamIn) -> None:
-        self.texture: Texture2D | None = Texture2D()
+        self.texture: Texture2D = Texture2D()
         super().__init__(stream)
 
     @property


### PR DESCRIPTION
This pull request seperates the reading and the object/business logic of the Texture2D reader into 2 files.